### PR TITLE
Fix rowcolor on local tex installations

### DIFF
--- a/imeko_acta.cls
+++ b/imeko_acta.cls
@@ -94,14 +94,15 @@
 \usepackage{microtype} % without this, with ebgaramond many lines go out of the margin due to hyphenation issues
 \RequirePackage{ifthen}
 \RequirePackage{ifpdf,ifxetex}      % Needed to pick between latex and pdflatex
-\RequirePackage{graphicx,xcolor}
+\RequirePackage{graphicx}
+\RequirePackage[table]{xcolor}
 \RequirePackage[fleqn]{amsmath}
 %\RequirePackage{indentfirst}
 \RequirePackage{caption}
 \RequirePackage{fancyhdr}  % Needed to define custom headers/footers
 %\RequirePackage{lastpage}  % Number of pages in the document
 \RequirePackage{enumitem}
-\RequirePackage{array,booktabs,tabularx,colortbl}
+\RequirePackage{array,booktabs,tabularx}
 \RequirePackage{cite}
 %only needed if we want to have a double column float *mandatory* at the bottom (because latex only put them at the top by default)
 \RequirePackage{stfloats}


### PR DESCRIPTION
The use of `rowcolor` in the redefinition of the `tabular` environment here [here](https://github.com/trama/Acta-Imeko-Latex-Class/blob/c8df01f3156b23b61dd5131904ed6d159a946f91/imeko_acta.cls#L288C1-L291C12`), caused a compile error on local tex installations (tested with TexLive 2022 on Ubuntu 22.04) while it works on Overleaf. 

This pull request fix the issue